### PR TITLE
fix: update cids and multiaddr

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3748,13 +3748,33 @@
       "dev": true
     },
     "cids": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/cids/-/cids-0.5.3.tgz",
-      "integrity": "sha512-ujWbNP8SeLKg5KmGrxYZM4c+ttd+wwvegrdtgmbi2KNFUbQN4pqsGZaGQE3rhjayXTbKFq36bYDbKhsnD0eMsg==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/cids/-/cids-0.5.5.tgz",
+      "integrity": "sha512-oU8v+N8rViFBcj5KcsXK0gbPiMFHpP/VGlGoWQXZguJsA8ZW0X47fKt0ZPIu03U8CL1Fy+R56tO79urY6MLaSw==",
       "requires": {
-        "multibase": "~0.4.0",
-        "multicodec": "~0.2.6",
-        "multihashes": "~0.4.13"
+        "class-is": "^1.1.0",
+        "multibase": "~0.5.0",
+        "multicodec": "~0.2.7",
+        "multihashes": "~0.4.14"
+      },
+      "dependencies": {
+        "multibase": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.5.0.tgz",
+          "integrity": "sha512-7epKiK8/UBzraYZvOuZa8FH/00hMfTnzTy1OQol1YBU2csAYA7rwWh+iue9plXRmVFBGvmVKMuo0oq5sD47kvw==",
+          "requires": {
+            "base-x": "3.0.4"
+          }
+        },
+        "multihashes": {
+          "version": "0.4.14",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.14.tgz",
+          "integrity": "sha512-V/g/EIN6nALXfS/xHUAgtfPP3mn3sPIF/i9beuGKf25QXS2QZYCpeVJbDPEannkz32B2fihzCe2D/KMrbcmefg==",
+          "requires": {
+            "bs58": "^4.0.1",
+            "varint": "^5.0.0"
+          }
+        }
       }
     },
     "cipher-base": {
@@ -4619,11 +4639,11 @@
       }
     },
     "cytoscape-dagre": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/cytoscape-dagre/-/cytoscape-dagre-2.2.1.tgz",
-      "integrity": "sha512-8HK1lCCRi5Jxt4spMTksYy/lZTCidu7FX2jovGbC2GCGum0Qd4HInOkn5ofMVdpWYE7FmynSbZDlDfbNtnglwA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/cytoscape-dagre/-/cytoscape-dagre-2.2.2.tgz",
+      "integrity": "sha512-zsg36qNwua/L2stJSWkcbSDcvW3E6VZf6KRe6aLnQJxuXuz89tMqI5EVYVKEcNBgzTEzFMFv0PE3T0nD4m6VDw==",
       "requires": {
-        "dagre": "^0.7.4"
+        "dagre": "^0.8.2"
       }
     },
     "d": {
@@ -4636,19 +4656,12 @@
       }
     },
     "dagre": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/dagre/-/dagre-0.7.4.tgz",
-      "integrity": "sha1-3nLw50pVDOEc5jjwoTb+1xI5gCI=",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/dagre/-/dagre-0.8.2.tgz",
+      "integrity": "sha512-TEOOGZOkCOgCG7AoUIq64sJ3d21SMv8tyoqteLpX+UsUsS9Qw8iap4hhogXY4oB3r0bbZuAjO0atAilgCmsE0Q==",
       "requires": {
-        "graphlib": "^1.0.5",
-        "lodash": "^3.10.0"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
-        }
+        "graphlib": "^2.1.5",
+        "lodash": "^4.17.4"
       }
     },
     "damerau-levenshtein": {
@@ -7296,18 +7309,11 @@
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "graphlib": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-1.0.7.tgz",
-      "integrity": "sha1-DKst8P/mq+BwsmJb+h7bbslnuLE=",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.5.tgz",
+      "integrity": "sha512-XvtbqCcw+EM5SqQrIetIKKD+uZVNQtDPD1goIg7K73RuRZtVI5rYMdcCVSHm/AS1sCBZ7vt0p5WgXouucHQaOA==",
       "requires": {
-        "lodash": "^3.10.0"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
-        }
+        "lodash": "^4.11.1"
       }
     },
     "growly": {
@@ -8138,6 +8144,18 @@
             "cids": "0.5.3",
             "multibase": "0.4.0",
             "multihashes": "0.4.13"
+          },
+          "dependencies": {
+            "cids": {
+              "version": "0.5.3",
+              "resolved": "http://registry.npmjs.org/cids/-/cids-0.5.3.tgz",
+              "integrity": "sha512-ujWbNP8SeLKg5KmGrxYZM4c+ttd+wwvegrdtgmbi2KNFUbQN4pqsGZaGQE3rhjayXTbKFq36bYDbKhsnD0eMsg==",
+              "requires": {
+                "multibase": "~0.4.0",
+                "multicodec": "~0.2.6",
+                "multihashes": "~0.4.13"
+              }
+            }
           }
         }
       }
@@ -10401,9 +10419,9 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "multiaddr": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-5.0.0.tgz",
-      "integrity": "sha512-IMEo+iCv53MT8c/6SQWbJpJUEENTYr6qp7o635BKJLQG2nkxOIO9LSEFhF5e56Az+DkmI6HGAAjp69AT7Sjulw==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-5.0.2.tgz",
+      "integrity": "sha512-dXz1chaUHV6L6okujDLS7uRA6NmCbitpikOJA0vMMnrwVyai5kC3ot2CSLrSfj3B8XIgNzpe/j5auSYrnbGGzA==",
       "requires": {
         "bs58": "^4.0.1",
         "class-is": "^1.1.0",
@@ -13819,9 +13837,9 @@
       }
     },
     "react-dev-utils": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-5.0.1.tgz",
-      "integrity": "sha512-+y92rG6pmXt3cpcg/NGmG4w/W309tWNSmyyPL8hCMxuCSg2UP/hUg3npACj2UZc8UKVSXexyLrCnxowizGoAsw==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-5.0.3.tgz",
+      "integrity": "sha512-Mvs6ofsc2xTjeZIrMaIfbXfsPVrbdVy/cVqq6SAacnqfMlcBpDuivhWZ1ODGeJ8HgmyWTLH971PYjj/EPCDVAw==",
       "dev": true,
       "requires": {
         "address": "1.0.3",
@@ -13836,10 +13854,10 @@
         "inquirer": "3.3.0",
         "is-root": "1.0.0",
         "opn": "5.2.0",
-        "react-error-overlay": "^4.0.0",
+        "react-error-overlay": "^4.0.1",
         "recursive-readdir": "2.2.1",
         "shell-quote": "1.6.1",
-        "sockjs-client": "1.1.4",
+        "sockjs-client": "1.1.5",
         "strip-ansi": "3.0.1",
         "text-table": "0.2.0"
       },
@@ -13869,22 +13887,24 @@
           "integrity": "sha512-ZH7loueKBoDb7yG9esn1U+fgq7BzlzW6NRi5/rMdxIZ05dj7GFD/Xc5rq2CDt5Yq86CyfSYVyx4242QQNZbx1g==",
           "dev": true
         },
-        "minimatch": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-          "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.0.0"
-          }
+        "react-error-overlay": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-4.0.1.tgz",
+          "integrity": "sha512-xXUbDAZkU08aAkjtUvldqbvI04ogv+a1XdHxvYuHPYKIVk/42BIOD0zSKTHAWV4+gDy3yGm283z2072rA2gdtw==",
+          "dev": true
         },
-        "recursive-readdir": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.1.tgz",
-          "integrity": "sha1-kO8jHQd4xc4JPJpI105cVCLROpk=",
+        "sockjs-client": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.5.tgz",
+          "integrity": "sha1-G7fA9yIsQPQq3xT0RCy9Eml3GoM=",
           "dev": true,
           "requires": {
-            "minimatch": "3.0.3"
+            "debug": "^2.6.6",
+            "eventsource": "0.1.6",
+            "faye-websocket": "~0.11.0",
+            "inherits": "^2.0.1",
+            "json3": "^3.3.2",
+            "url-parse": "^1.1.8"
           }
         },
         "supports-color": {
@@ -13921,12 +13941,6 @@
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.0"
       }
-    },
-    "react-error-overlay": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-4.0.0.tgz",
-      "integrity": "sha512-FlsPxavEyMuR6TjVbSSywovXSEyOg6ZDj5+Z8nbsRl9EkOzAhEIcS+GLoQDC5fz/t9suhUXWmUrOBrgeUvrMxw==",
-      "dev": true
     },
     "react-fuzzy": {
       "version": "0.5.2",
@@ -15626,20 +15640,6 @@
         }
       }
     },
-    "sockjs-client": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.4.tgz",
-      "integrity": "sha1-W6vjhrd15M8U51IJEUUmVAFsixI=",
-      "dev": true,
-      "requires": {
-        "debug": "^2.6.6",
-        "eventsource": "0.1.6",
-        "faye-websocket": "~0.11.0",
-        "inherits": "^2.0.1",
-        "json3": "^3.3.2",
-        "url-parse": "^1.1.8"
-      }
-    },
     "sort-keys": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
@@ -17007,9 +17007,9 @@
       }
     },
     "url-parse": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.1.tgz",
-      "integrity": "sha512-x95Td74QcvICAA0+qERaVkRpTGKyBHHYdwL2LXZm5t/gBtCB9KQSO/0zQgSTYEV1p0WcvSg79TLNPSvd5IDJMQ==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.4.tgz",
+      "integrity": "sha512-/92DTTorg4JjktLNLe6GPS2/RvAd/RGr6LuktmWSMLEOa6rjnlrFXNgSbSmkNvCoL2T028A0a1JaJLzRMlFoHg==",
       "dev": true,
       "requires": {
         "querystringify": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -24,14 +24,14 @@
   "dependencies": {
     "@tableflip/react-inspector": "^2.3.0",
     "babel-cli": "^6.26.0",
-    "cids": "^0.5.3",
+    "cids": "^0.5.5",
     "cytoscape": "^3.2.14",
-    "cytoscape-dagre": "^2.2.1",
+    "cytoscape-dagre": "^2.2.2",
     "filesize": "^3.6.1",
     "ipfs-unixfs": "^0.1.15",
     "ipld-dag-pb": "^0.14.8",
     "milliseconds": "^1.0.3",
-    "multiaddr": "^5.0.0",
+    "multiaddr": "^5.0.2",
     "multibase": "^0.4.0",
     "multicodec": "^0.2.7",
     "multihashes": "^0.4.13"


### PR DESCRIPTION
This PR bumps some deps.  

Old versions cause known issues:
- https://github.com/ipfs-shipyard/ipfs-webui/pull/874
- https://github.com/multiformats/js-multiaddr/pull/71

@olizilla we should release this and update http://explore.ipld.io to the latest version (right now it is broken with `window.ipfs` due to old cids, as described in https://github.com/ipfs-shipyard/ipfs-webui/pull/874)