### PR TITLE
fix: fix empty arrays throwing error in dag-cbor types

### DIFF
--- a/src/lib/normalise-dag-node.js
+++ b/src/lib/normalise-dag-node.js
@@ -90,6 +90,8 @@ export function findAndReplaceDagCborLinks (obj, sourceCid, path = '') {
   }
 
   if (Array.isArray(obj)) {
+    if (!obj.length) return []
+
     return obj
       .map((val, i) => findAndReplaceDagCborLinks(val, sourceCid, path ? `${path}/${i}` : `${i}`))
       .reduce((a, b) => a.concat(b))

--- a/src/lib/normalize-dag-node.test.js
+++ b/src/lib/normalize-dag-node.test.js
@@ -1,0 +1,65 @@
+/* global it expect */
+import normaliseDagCbor from './normalise-dag-node'
+
+const cid1 = 'zdpuAwkGh9cLskW5z7pH8V2uC5nwtSXd76L7ZTEXs5f8V89db'
+const cid2 = 'zdpuAydka8ZEXd9UgWF1s4pVFcF4U1GEgtdNQFxKNt9tyKQxR'
+const cid3 = 'zdpuAtYsbfdkVazNyWcS97cWKVzR99huDzNxMmoRb349jyUTD'
+
+it('normalizes a simple cbor node', () => {
+  const obj = { foo: 'bar' }
+  const res = normaliseDagCbor(obj, cid1, 'dag-cbor')
+
+  expect(res).toEqual({
+    cid: cid1,
+    data: obj,
+    type: 'dag-cbor',
+    links: []
+  })
+})
+
+it('normalizes a cbor node with an empty array', () => {
+  const obj = { foo: [] }
+  const res = normaliseDagCbor(obj, cid1, 'dag-cbor')
+
+  expect(res).toEqual({
+    cid: cid1,
+    data: obj,
+    type: 'dag-cbor',
+    links: []
+  })
+})
+
+it('normalizes a cbor node with links', () => {
+  const obj = {
+    foo: { '/': cid2 },
+    bar: [
+      { '/': cid2 },
+      { '/': cid3 }
+    ]
+  }
+
+  const res = normaliseDagCbor(obj, cid1, 'dag-cbor')
+
+  expect(res).toEqual({
+    cid: cid1,
+    data: obj,
+    type: 'dag-cbor',
+    links: [
+      {
+        path: 'foo',
+        source: cid1,
+        target: cid2
+      },
+      {
+        path: 'bar/0',
+        source: cid1,
+        target: cid2
+      },
+      {
+        path: 'bar/1',
+        source: cid1,
+        target: cid3
+      }
+    ]
+  })
+})


### PR DESCRIPTION
Also added some tests for the normalization of dag-cbor types

See: https://github.com/ipfs-shipyard/ipld-explorer/issues/46