### PR TITLE
fix: show as many node links as height allows

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {
-    "build": "cross-env NODE_ENV=production babel src -d dist --copy-files --ignore '**/*.test.js'",
+    "build": "cross-env NODE_ENV=production babel --quiet src -d dist --copy-files --ignore '**/*.test.js'",
     "clean": "rm -rf dist",
     "lint": "standard",
     "prepare": "npm run build",

--- a/src/components/object-info/LinksTable.js
+++ b/src/components/object-info/LinksTable.js
@@ -13,7 +13,7 @@ class LinksTable extends React.Component {
     const headerClassName = 'mid-gray fw2 tracked silver'
     const rowHeight = 29
     const headerHeight = 32
-    const tableHeight = Math.min(370, (links.length * rowHeight) + headerHeight)
+    const tableHeight = Math.max(370, (Math.min(window.innerHeight - 500, links.length * rowHeight + headerHeight)));
     return (
       <div>
         <AutoSizer disableHeight>

--- a/src/components/object-info/LinksTable.js
+++ b/src/components/object-info/LinksTable.js
@@ -13,7 +13,7 @@ class LinksTable extends React.Component {
     const headerClassName = 'mid-gray fw2 tracked silver'
     const rowHeight = 29
     const headerHeight = 32
-    const tableHeight = Math.max(370, (Math.min(window.innerHeight - 500, links.length * rowHeight + headerHeight)));
+    const tableHeight = Math.max(370, (Math.min(window.innerHeight - 500, links.length * rowHeight + headerHeight)))
     return (
       <div>
         <AutoSizer disableHeight>


### PR DESCRIPTION
Not sure if this is too hacky a suggestion, but enables full-height link tables by way of nesting `math`:

`tableHeight` is the greater of either 370px or (_the lesser of either "window height less page header height" or "the number of rows x row height plus table header height"_)

Note that 370px is the current max height.

Closes https://github.com/ipfs-shipyard/ipld-explorer/issues/53.