### PR TITLE
fix(css): make gateway links responsive

### DIFF
--- a/src/components/object-info/ObjectInfo.js
+++ b/src/components/object-info/ObjectInfo.js
@@ -74,16 +74,16 @@ const ObjectInfo = ({ t, tReady, className, type, cid, localPath, size, data, li
           <a className='dn di-ns no-underline charcoal ml2' href='https://docs.ipfs.io/concepts/glossary/#unixfs' rel='external' target='_external'>UnixFS</a>
         ) : null}
         {format === 'unixfs' && data.type && ['directory', 'file'].some(x => x === data.type) ? (
-          <>
+          <span className='dib'>
             {gatewayUrl && gatewayUrl !== publicGatewayUrl && (
-              <a className='no-underline avenir ml2 pa2 fw5 f6 blue' href={`${gatewayUrl}/ipfs/${cid}`} rel='external nofollow' target='_external'>
+              <a className='no-underline avenir ml2 pa2 fw5 f6 navy dib' href={`${gatewayUrl}/ipfs/${cid}`} rel='external nofollow' target='_external'>
                 {t('ObjectInfo.privateGateway')}
               </a>)}
             {publicGatewayUrl && (
-              <a className='no-underline avenir ml2 pa2 fw5 f6 blue' href={`${publicGatewayUrl}/ipfs/${cid}`} rel='external nofollow' target='_external'>
+              <a className='no-underline avenir ml2 pa2 fw5 f6 navy dib' href={`${publicGatewayUrl}/ipfs/${cid}`} rel='external nofollow' target='_external'>
                 {t('ObjectInfo.publicGateway')}
               </a>)}
-          </>
+          </span>
         ) : null}
       </h2>
       <div className='f6'>


### PR DESCRIPTION
Reflow introduced in https://github.com/ipfs/ipld-explorer-components/pull/300
was wrapping the label, this replaces labels with inlined blocks,
ensuring user-friendly reflow at the block level.

>![2022-06-06_20-14](https://user-images.githubusercontent.com/157609/172222698-1be278c9-e3c4-45e5-b636-104b6e37e40c.png)

> ![2022-06-06_20-13_1](https://user-images.githubusercontent.com/157609/172222721-849268f1-65c4-4ef8-b9fb-abd5e8c105a3.png)

> ![2022-06-06_20-13](https://user-images.githubusercontent.com/157609/172222744-264098d6-d9b4-4767-bc0e-a9375ac55196.png)
